### PR TITLE
Fix P&L Calculation and Add Lot Multiplier

### DIFF
--- a/src/components/trade/TradeForm.vue
+++ b/src/components/trade/TradeForm.vue
@@ -106,6 +106,10 @@ const toastTitle = ref('')
 const toastMessage = ref('')
 const showToastOverlay = ref(false)
 
+// P&L calculation state
+const isPnlManuallyEdited = ref(false)
+const lastCalculatedPnl = ref(0)
+
 // Trade data
 const trade = ref({
   tradeId: uuidv4(),
@@ -117,6 +121,7 @@ const trade = ref({
   entryDate: new Date().toISOString().slice(0, 10), // Set today as default
   exitDate: '',
   lots: 2,
+  lotMultiplier: 1,
   daysHeld: 0,
   capitalUsed: null,
   fundingCharge: null,
@@ -147,10 +152,16 @@ const showToast = (variant, title, message) => {
 
 // P&L calculations
 const calculatePnL = () => {
+  if (isPnlManuallyEdited.value) {
+    updateReturnFromPnL()
+    return
+  }
+
   if (trade.value.entryPrice && trade.value.lots && trade.value.capitalUsed) {
     const entryPrice = parseFloat(trade.value.entryPrice.toString())
     const capitalUsed = parseFloat(trade.value.capitalUsed.toString())
     const lots = parseFloat(trade.value.lots.toString())
+    const lotMultiplier = parseFloat((trade.value.lotMultiplier || 1).toString())
 
     if (!isNaN(entryPrice) && !isNaN(lots) && !isNaN(capitalUsed)) {
       let totalPnL = 0
@@ -164,7 +175,7 @@ const calculatePnL = () => {
           const exitLots = parseFloat((exit.lots || '').toString())
 
           if (!isNaN(exitPrice) && !isNaN(exitLots)) {
-            const partialPnL = (exitPrice - entryPrice) * exitLots * multiplier
+            const partialPnL = (exitPrice - entryPrice) * exitLots * multiplier * lotMultiplier
             totalPnL += partialPnL
             remainingLots -= exitLots
           }
@@ -175,7 +186,7 @@ const calculatePnL = () => {
       if (remainingLots > 0) {
         const exitPriceString = trade.value.exitPrice ? trade.value.exitPrice.toString() : ''
         const exitPrice = exitPriceString ? parseFloat(exitPriceString) : entryPrice
-        const remainingPnL = (exitPrice - entryPrice) * remainingLots * multiplier
+        const remainingPnL = (exitPrice - entryPrice) * remainingLots * multiplier * lotMultiplier
         totalPnL += remainingPnL
       }
 
@@ -183,11 +194,13 @@ const calculatePnL = () => {
       const tradingCharge = parseFloat((trade.value.tradingCharge || 0).toString())
 
       pnl.value.amount = totalPnL + fundingCharge - tradingCharge
+      lastCalculatedPnl.value = pnl.value.amount
       updateReturnFromPnL()
     }
   } else if (!editingTrade.value?.pnlAmount) {
     pnl.value.amount = 0
     pnl.value.percentage = 0
+    lastCalculatedPnl.value = 0
   }
 }
 
@@ -204,6 +217,10 @@ const updateReturnFromPnL = () => {
 
 const updatePnLFromAmount = (newPnL) => {
   pnl.value = newPnL
+  // If the user manually changed the amount, mark it so it's not overwritten
+  if (Math.abs(newPnL.amount - lastCalculatedPnl.value) > 0.00001) {
+    isPnlManuallyEdited.value = true
+  }
 }
 
 const updateCharges = ({ field, value }) => {
@@ -224,6 +241,7 @@ const cleanNumericFields = (data) => {
     'entryPrice',
     'exitPrice',
     'lots',
+    'lotMultiplier',
     'capitalUsed',
     'fundingCharge',
     'tradingCharge',
@@ -344,6 +362,7 @@ const resetForm = () => {
     entryDate: today, // Set today as default entry date
     exitDate: '',
     lots: 2,
+    lotMultiplier: 1,
     daysHeld: 0,
     capitalUsed: null,
     fundingCharge: null,
@@ -364,12 +383,14 @@ const resetForm = () => {
     amount: 0,
     percentage: 0
   }
+  isPnlManuallyEdited.value = false
+  lastCalculatedPnl.value = 0
 }
 
-// Watchers
 watch(editingTrade, (newTrade) => {
   if (newTrade) {
     trade.value = { ...newTrade }
+    isPnlManuallyEdited.value = false
   }
 })
 

--- a/src/components/trade/forms/TradePricing.vue
+++ b/src/components/trade/forms/TradePricing.vue
@@ -50,6 +50,23 @@
         >
       </div>
       <div class="form-group">
+        <label for="lotMultiplier">Lot Multiplier</label>
+        <input
+          id="lotMultiplier"
+          type="text"
+          :value="modelValue.lotMultiplier"
+          required
+          min="1"
+          step="1"
+          inputmode="numeric"
+          pattern="[0-9]*"
+          @input="handleNumberChange('lotMultiplier', $event)"
+        >
+      </div>
+    </div>
+
+    <div class="form-row">
+      <div class="form-group">
         <label for="capitalUsed">Capital Used</label>
         <div class="input-with-prefix">
           <span class="currency-prefix">{{ currencySymbol }}</span>

--- a/src/components/trade/forms/TradeSummary.vue
+++ b/src/components/trade/forms/TradeSummary.vue
@@ -12,7 +12,7 @@
             step="0.00001"
             :class="{ 'profit': pnl.amount > 0, 'loss': pnl.amount < 0 }"
             inputmode="decimal"
-            pattern="[0-9]*\.?[0-9]*"
+            pattern="^-?[0-9]*\.?[0-9]*$"
             @input="handlePnLAmountChange"
           >
         </div>


### PR DESCRIPTION
## Pull Request: Fix P&L Calculation and Add Lot Multiplier

### Summary

This PR addresses an issue where P&L calculations were incorrect for trades with multiple partial exits or specific contract sizes (like PIPPIN). It introduces a "Lot Multiplier" field to handle various asset contract sizes and implements a manual override protection to prevent automated calculations from overwriting user-edited P&L values. Additionally, it fixes a validation error that prevented negative P&L values from being recorded.

### Changes Made

- **Trade Logic & P&L Calculation**:
  - Introduced `lotMultiplier` to the trade state to handle diverse contract sizes (e.g., set to 100 for assets like PIPPIN).
  - Implemented `isPnlManuallyEdited` tracking to preserve manual P&L entries during subsequent form updates or partial exit additions.
  - Updated `calculatePnL` to incorporate the `lotMultiplier` and respect manual overrides.
- **UI Components**:
  - **TradePricing.vue**: Added a "Lot Multiplier" input field next to the "Size" field.
  - **TradeSummary.vue**: Updated the P&L Amount input validation pattern (`^-?[0-9]*\.?[0-9]*$`) to correctly allow negative numbers (losses).
- **Quality of Life**:
  - Ensured `lotMultiplier` is correctly cleaned, saved, and reset in the trade form lifecycle.

### Files Changed

| File | Change |
| --- | --- |
| `src/components/trade/TradeForm.vue` | Added lotMultiplier state, updated P&L calculation logic, and added manual override protection. |
| `src/components/trade/forms/TradePricing.vue` | Added Lot Multiplier input field to the UI. |
| `src/components/trade/forms/TradeSummary.vue` | Fixed regex pattern to allow negative P&L values. |

### Testing Done

- [x] Verified P&L calculation for PIPPIN trade (Multiplier 100) matches exchange values.
- [x] Verified manual P&L edits are preserved when adding/removing partial exits.
- [x] Verified negative P&L values can be entered without validation errors.
- [x] Confirmed `Return %` correctly reflects manual P&L edits.

### Notes / Breaking Changes

- Existing trades will default to a `lotMultiplier` of 1, maintaining backward compatibility.
- Users trading assets with non-standard contract sizes should update the "Lot Multiplier" field accordingly.
